### PR TITLE
Card scan rework

### DIFF
--- a/src/apps/cards/tests.py
+++ b/src/apps/cards/tests.py
@@ -23,7 +23,6 @@ class CardsViewsTest(TestCase):
         self.assertEqual(vor.card_name, "Vortex-9")
         self.assertEqual(cru.card_name, "Crudespawn")
 
-
     def test_get_pack_instance(self):
         """
         Tests that get_pack_instance gets or creates the rest of the cards
@@ -32,10 +31,9 @@ class CardsViewsTest(TestCase):
         pack = get_pack_instance()
         self.assertIs(type(pack), Pack)
 
-
     def test_create_card_visitors(self):
         """
-        Tests to see if a visitor entry is created in the card_visitors dict
+        Tests to see if a visitor entry is created in the card_visitors dict for timed and non-timed.
         """
         card_name = "Ooga"
         create_card_visitors(card_name)
@@ -46,20 +44,26 @@ class CardsViewsTest(TestCase):
         create_card_visitors(card_name)
         self.assertEqual(card_scan_visitors.get("ooga1_visitors"), [])
 
+        # Tests timed entry
+        create_card_visitors(card_name, True)
+        self.assertEqual(card_scan_visitors.get("ooga2_visitors"), {})
         
     def test_create_pack_visitors(self):
         """
-        Tests to see if a visitor entry is created in the pack_visitors dict
+        Tests to see if a visitor entry is created in the pack_visitors dict for timed and non-timed.
         """
         pack_name = "Ooga"
         create_pack_visitors(pack_name)
-        self.assertEqual(pack_scan_visitors.get("ooga0_visitors"), dict())
+        self.assertEqual(pack_scan_visitors.get("ooga0_visitors"), [])
 
         # Tests to see that it creates a new entry with a different index
         # Simulates different websites with the same pack reward and tracking its visitors
         create_pack_visitors(pack_name)
-        self.assertEqual(pack_scan_visitors.get("ooga1_visitors"), dict())
+        self.assertEqual(pack_scan_visitors.get("ooga1_visitors"), [])
 
+        # Tests timed entry
+        create_pack_visitors(pack_name, True)
+        self.assertEqual(pack_scan_visitors.get("ooga2_visitors"), {})
         
     def test_add_card_website(self):
         """
@@ -71,19 +75,27 @@ class CardsViewsTest(TestCase):
         hyd = cards.get("hyd")
         newID1 = uuid4()
         newID2 = uuid4()
-
-        strID1 = str(newID1)
-        strID2 = str(newID2)
+        newID3 = uuid4()
+        newID4 = uuid4()
 
         # Tests adding a website to existing card
         add_card_website(hyd, newID1)
-        self.assertIn(strID1, card_scan_UUIDs.get(f"{hyd.card_name}_UUIDs"))
+        self.assertIn(str(newID1), card_scan_UUIDs.get(f"{hyd.card_name}_UUIDs"))
 
         booga = Card.objects.create(card_name="Booga")
         # Tests adding a website for a new card
         add_card_website(booga, newID2)
-        self.assertIn(strID2, card_scan_UUIDs.get(f"{booga.card_name}_UUIDs"))
+        self.assertIn(str(newID2), card_scan_UUIDs.get(f"{booga.card_name}_UUIDs"))
 
+
+        # Tests adding a timed website to existing card
+        add_card_website(hyd, newID3, True)
+        self.assertIn(str(newID3), card_scan_UUIDs.get(f"{hyd.card_name}_UUIDs"))
+
+        wooga = Card.objects.create(card_name="Wooga")
+        # Tests adding a timed website for a new card
+        add_card_website(wooga, newID4, True)
+        self.assertIn(str(newID4), card_scan_UUIDs.get(f"{wooga.card_name}_UUIDs"))
 
     def test_add_pack_website(self):
         """
@@ -94,18 +106,28 @@ class CardsViewsTest(TestCase):
 
         newID1 = uuid4()
         newID2 = uuid4()
-        strID1 = str(newID1)
-        strID2 = str(newID2)
+        newID3 = uuid4()
+        newID4 = uuid4()
+
 
         # Tests adding a website to existing pack
         add_pack_website(pack, newID1)
-        self.assertIn(strID1, pack_scan_UUIDs.get(f"{pack.pack_name}_UUIDs"))
+        self.assertIn(str(newID1), pack_scan_UUIDs.get(f"{pack.pack_name}_UUIDs"))
 
         pack1 = Pack.objects.create(pack_name="packUno", cost=10, num_cards="0")
         # Tests adding a website for a new pack
         add_pack_website(pack1, newID2)
-        self.assertIn(strID2, pack_scan_UUIDs.get(f"{pack1.pack_name}_UUIDs"))
+        self.assertIn(str(newID2), pack_scan_UUIDs.get(f"{pack1.pack_name}_UUIDs"))
 
+
+        # Tests adding a timed website to existing pack
+        add_pack_website(pack, newID3, True)
+        self.assertIn(str(newID3), pack_scan_UUIDs.get(f"{pack.pack_name}_UUIDs"))
+
+        pack2 = Pack.objects.create(pack_name="packDos", cost=10, num_cards="0")
+        # Tests adding a timed website for a new pack
+        add_pack_website(pack2, newID4, True)
+        self.assertIn(str(newID4), pack_scan_UUIDs.get(f"{pack2.pack_name}_UUIDs"))
 
     def test_get_card_from_ID(self):
         """
@@ -118,7 +140,6 @@ class CardsViewsTest(TestCase):
         add_card_website(awooga, newID1)
         self.assertEqual(get_card_from_ID(strID1), awooga)
         self.assertIsNone(get_pack_from_ID(00))
-
 
     def test_get_pack_from_ID(self):
         """
@@ -152,7 +173,6 @@ class CardTest(TestCase):
         self.assertEqual(uno_card.image, PurePath("images/card_images/Missing_Texture.png").as_posix())
         self.assertEqual(grunty_card.image, PurePath("images/card_images/Test.jpg").as_posix())
 
-    
     def test_change_image(self):
         """
         Tests to see if Card is able to change the image to an existing file

--- a/src/apps/cards/tests.py
+++ b/src/apps/cards/tests.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 from apps.cards.models import Card, Pack, PackCards
-from apps.cards.views import get_cards_instance, get_pack_instance
+from apps.cards.views import get_cards_instance, get_pack_instance, add_card_website, create_pack_visitors, add_pack_website, create_card_visitors, card_scan_UUIDs, card_scan_visitors, pack_scan_UUIDs, pack_scan_visitors
 from pathlib import PurePath
+from uuid import uuid4
 
 class CardsViewsTest(TestCase):
 
@@ -25,19 +26,79 @@ class CardsViewsTest(TestCase):
     def test_get_pack_instance(self):
         """
         Tests that get_pack_instance gets or creates the rest of the cards
-        for the pack. Adds cards to the pack and then returns a list of 
-        tuples containing the Card and rarity.
+        for the pack. Adds cards to the pack and then returns a pack object
         """
         pack = get_pack_instance()
-        #for i in range(len(pack)):
-            #place = i+1
-            #name, rar = pack[i]
-            #print(str(place)+":",name, rar)
-        self.assertEqual(len(pack), 10)
-        for card in pack:
-            self.assertEqual(card[1], 100)
+        self.assertIs(type(pack), Pack)
 
 
+    def test_create_card_visitors(self):
+        """
+        Tests to see if a visitor entry is created in the card_visitors dict
+        """
+        card_name_lower = "ooga"
+        create_card_visitors(card_name_lower)
+        self.assertEqual(card_scan_visitors.get(card_name_lower+"0_visitors"), [])
+
+        # Tests to see that it creates a new entry with a different index
+        # Simulates different websites with the same card reward and tracking its visitors
+        create_card_visitors(card_name_lower)
+        self.assertEqual(card_scan_visitors.get(card_name_lower+"1_visitors"), [])
+
+        
+    def test_create_pack_visitors(self):
+        """
+        Tests to see if a visitor entry is created in the pack_visitors dict
+        """
+        pack_name_lower = "ooga"
+        create_pack_visitors(pack_name_lower)
+        self.assertEqual(pack_scan_visitors.get(pack_name_lower+"0_visitors"), dict())
+
+        # Tests to see that it creates a new entry with a different index
+        # Simulates different websites with the same pack reward and tracking its visitors
+        create_pack_visitors(pack_name_lower)
+        self.assertEqual(pack_scan_visitors.get(pack_name_lower+"1_visitors"), dict())
+
+        
+    def test_add_card_website(self):
+        cards = get_cards_instance()
+
+        hyd = cards.get("hyd")
+        card_name_lower = hyd.card_name.lower()
+        newID1 = uuid4()
+        newID2 = uuid4()
+
+        strID1 = str(newID1)
+        strID2 = str(newID2)
+
+        # Tests adding a website to existing card
+        add_card_website(hyd, newID1)
+        self.assertIn(strID1, card_scan_UUIDs.get(f"{card_name_lower}_UUIDs"))
+
+        booga = Card.objects.create(card_name="Booga")
+        # Tests adding a website for a new card
+        add_card_website(booga, newID2)
+        self.assertIn(strID2, card_scan_UUIDs.get(f"booga_UUIDs"))
+
+
+    def test_add_pack_website(self):
+        pack = get_pack_instance()
+
+        newID1 = uuid4()
+        newID2 = uuid4()
+        strID1 = str(newID1)
+        strID2 = str(newID2)
+
+        pack_name_lower = pack.pack_name.lower()
+
+        # Tests adding a website to existing pack
+        add_pack_website(pack, newID1)
+        self.assertIn(strID1, pack_scan_UUIDs.get(f"{pack_name_lower}_UUIDs"))
+
+        pack1 = Pack.objects.create(pack_name="packUno", cost="10", num_cards="0")
+        # Tests adding a website for a new pack
+        add_pack_website(pack1, newID2)
+        self.assertIn(strID2, pack_scan_UUIDs.get("packuno_UUIDs"))
 
 
 class CardTest(TestCase):

--- a/src/apps/cards/tests.py
+++ b/src/apps/cards/tests.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from apps.cards.models import Card, Pack, PackCards
-from apps.cards.views import get_cards_instance, get_pack_instance, add_card_website, create_pack_visitors, add_pack_website, create_card_visitors, card_scan_UUIDs, card_scan_visitors, pack_scan_UUIDs, pack_scan_visitors
+from apps.cards.views import get_pack_from_ID, get_card_from_ID, get_cards_instance, get_pack_instance, add_card_website, create_pack_visitors, add_pack_website, create_card_visitors, card_scan_UUIDs, card_scan_visitors, pack_scan_UUIDs, pack_scan_visitors
 from pathlib import PurePath
 from uuid import uuid4
 
@@ -23,6 +23,7 @@ class CardsViewsTest(TestCase):
         self.assertEqual(vor.card_name, "Vortex-9")
         self.assertEqual(cru.card_name, "Crudespawn")
 
+
     def test_get_pack_instance(self):
         """
         Tests that get_pack_instance gets or creates the rest of the cards
@@ -36,35 +37,38 @@ class CardsViewsTest(TestCase):
         """
         Tests to see if a visitor entry is created in the card_visitors dict
         """
-        card_name_lower = "ooga"
-        create_card_visitors(card_name_lower)
-        self.assertEqual(card_scan_visitors.get(card_name_lower+"0_visitors"), [])
+        card_name = "Ooga"
+        create_card_visitors(card_name)
+        self.assertEqual(card_scan_visitors.get("ooga0_visitors"), [])
 
         # Tests to see that it creates a new entry with a different index
         # Simulates different websites with the same card reward and tracking its visitors
-        create_card_visitors(card_name_lower)
-        self.assertEqual(card_scan_visitors.get(card_name_lower+"1_visitors"), [])
+        create_card_visitors(card_name)
+        self.assertEqual(card_scan_visitors.get("ooga1_visitors"), [])
 
         
     def test_create_pack_visitors(self):
         """
         Tests to see if a visitor entry is created in the pack_visitors dict
         """
-        pack_name_lower = "ooga"
-        create_pack_visitors(pack_name_lower)
-        self.assertEqual(pack_scan_visitors.get(pack_name_lower+"0_visitors"), dict())
+        pack_name = "Ooga"
+        create_pack_visitors(pack_name)
+        self.assertEqual(pack_scan_visitors.get("ooga0_visitors"), dict())
 
         # Tests to see that it creates a new entry with a different index
         # Simulates different websites with the same pack reward and tracking its visitors
-        create_pack_visitors(pack_name_lower)
-        self.assertEqual(pack_scan_visitors.get(pack_name_lower+"1_visitors"), dict())
+        create_pack_visitors(pack_name)
+        self.assertEqual(pack_scan_visitors.get("ooga1_visitors"), dict())
 
         
     def test_add_card_website(self):
+        """
+        Tests that an id entry is added to a card's id list. Creates a new dict key with if card doesn't already exist.
+        Also creates a related corresponding visitors entry to card visitors list.
+        """
         cards = get_cards_instance()
 
         hyd = cards.get("hyd")
-        card_name_lower = hyd.card_name.lower()
         newID1 = uuid4()
         newID2 = uuid4()
 
@@ -73,15 +77,19 @@ class CardsViewsTest(TestCase):
 
         # Tests adding a website to existing card
         add_card_website(hyd, newID1)
-        self.assertIn(strID1, card_scan_UUIDs.get(f"{card_name_lower}_UUIDs"))
+        self.assertIn(strID1, card_scan_UUIDs.get(f"{hyd.card_name}_UUIDs"))
 
         booga = Card.objects.create(card_name="Booga")
         # Tests adding a website for a new card
         add_card_website(booga, newID2)
-        self.assertIn(strID2, card_scan_UUIDs.get(f"booga_UUIDs"))
+        self.assertIn(strID2, card_scan_UUIDs.get(f"{booga.card_name}_UUIDs"))
 
 
     def test_add_pack_website(self):
+        """
+        Tests that an id entry is added to a pack's id list. Creates a new dict key with if pack doesn't already exist.
+        Also creates a related corresponding visitors entry to pack visitors list.
+        """
         pack = get_pack_instance()
 
         newID1 = uuid4()
@@ -89,16 +97,41 @@ class CardsViewsTest(TestCase):
         strID1 = str(newID1)
         strID2 = str(newID2)
 
-        pack_name_lower = pack.pack_name.lower()
-
         # Tests adding a website to existing pack
         add_pack_website(pack, newID1)
-        self.assertIn(strID1, pack_scan_UUIDs.get(f"{pack_name_lower}_UUIDs"))
+        self.assertIn(strID1, pack_scan_UUIDs.get(f"{pack.pack_name}_UUIDs"))
 
-        pack1 = Pack.objects.create(pack_name="packUno", cost="10", num_cards="0")
+        pack1 = Pack.objects.create(pack_name="packUno", cost=10, num_cards="0")
         # Tests adding a website for a new pack
         add_pack_website(pack1, newID2)
-        self.assertIn(strID2, pack_scan_UUIDs.get("packuno_UUIDs"))
+        self.assertIn(strID2, pack_scan_UUIDs.get(f"{pack1.pack_name}_UUIDs"))
+
+
+    def test_get_card_from_ID(self):
+        """
+        Tests that you're able to get a card when given a valid id and returns None if it doesn't exist
+        """
+        awooga = Card.objects.create(card_name="Awooga")
+        newID1 = uuid4()
+        strID1 = str(newID1)
+
+        add_card_website(awooga, newID1)
+        self.assertEqual(get_card_from_ID(strID1), awooga)
+        self.assertIsNone(get_pack_from_ID(00))
+
+
+    def test_get_pack_from_ID(self):
+        """
+        Tests that you're able to get a pack when given a valid id and returns None if it doesn't exist
+        """
+        packo = Pack.objects.create(pack_name="Packo", cost=10, num_cards="0")
+        newID1 = uuid4()
+        strID1 = str(newID1)
+
+        add_pack_website(packo, newID1)
+        self.assertEqual(get_pack_from_ID(strID1), packo)
+        self.assertIsNone(get_pack_from_ID(00))
+
 
 
 class CardTest(TestCase):

--- a/src/apps/cards/urls.py
+++ b/src/apps/cards/urls.py
@@ -3,6 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("card_scan/<uuid:url_UUID>/", views.card_scan),
-    path("pack_scan/<uuid:url_UUID>/", views.pack_scan),
+    path("card-scan/<uuid:url_UUID>/", views.card_scan),
+    path("pack-scan/<uuid:url_UUID>/", views.pack_scan),
 ]

--- a/src/apps/cards/views.py
+++ b/src/apps/cards/views.py
@@ -39,7 +39,7 @@ def get_pack_instance()->Pack:
     rea = Card.objects.get_or_create(card_name="REACT-O-TRON", image="/images/card_images/REACT-O-TRON.jpg", card_desc="WIP")[0]
     the = Card.objects.get_or_create(card_name="Thermagon", image="/images/card_images/Thermagon.jpg", card_desc="WIP")[0]
 
-    pack = Pack.objects.get_or_create(pack_name="Electri-city squad", cost=250, num_cards=10)[0]
+    pack = Pack.objects.get_or_create(pack_name="pakwan", cost=250, num_cards=10)[0]
     if pack.get_all_cards().count() == 0:
         pack.add_to_pack(first_cards.get("vor"), 100)
         pack.add_to_pack(first_cards.get("hyd"), 100)
@@ -57,25 +57,25 @@ def get_pack_instance()->Pack:
     return pack
 
 card_scan_UUIDs = {
-    "vortex-9_UUIDs": ['4012cf77-7b46-4c2c-90f0-a1b821a123ea'],
-    "hydronis_UUIDs": ['24d79f65-4a8e-4f77-8bf4-b2447cf7ebcf'],
-    "crudespawn_UUIDs": ['bc9519d9-0adc-43d7-8912-13611c80fd38']
+    "Vortex-9_UUIDs": ['4012cf77-7b46-4c2c-90f0-a1b821a123ea'],
+    "Hydronis_UUIDs": ['24d79f65-4a8e-4f77-8bf4-b2447cf7ebcf'],
+    "Crudespawn_UUIDs": ['bc9519d9-0adc-43d7-8912-13611c80fd38']
 }
 
 pack_scan_UUIDs = {
-    "pack0_UUIDs": ['8408d587-9b62-4d34-8dd7-4bfec213f443'],
+    "pakwan_UUIDs": ['8408d587-9b62-4d34-8dd7-4bfec213f443'],
 }
 
 # A new entry will be created for new QR code with the repective index number
 card_scan_visitors = {
-    "vortex0_visitors": [],
+    "vortex-90_visitors": [],
     "hydronis0_visitors": [],
     "crudespawn0_visitors": [],
 }
 
 pack_scan_visitors = {
     # Dict cotaining userID and epoch time
-    "pack0_visitor_IDs": dict(), 
+    "pakwan0_visitors": dict(), 
 }
 
 # .===========.
@@ -91,17 +91,17 @@ def add_card_website(card: Card, website_ID):
     if type(website_ID) != str:
         website_ID = str(website_ID)
 
-    card_name_lower = card.card_name.lower()
-    card_key = card_name_lower + "_UUIDs"
+    card_name = card.card_name
+    card_key = card_name + "_UUIDs"
     target_card_scan_UUID = card_scan_UUIDs.get(card_key)
 
     if target_card_scan_UUID != None:
         target_card_scan_UUID.append(website_ID)
-        create_card_visitors(card_name_lower)
+        create_card_visitors(card_name)
 
     else:
         card_scan_UUIDs[card_key] = [website_ID]
-        create_card_visitors(card_name_lower)
+        create_card_visitors(card_name)
 
 
 def add_pack_website(pack: Pack, website_ID):
@@ -114,54 +114,79 @@ def add_pack_website(pack: Pack, website_ID):
     if type(website_ID) != str:
         website_ID = str(website_ID)
 
-    pack_name_lower = pack.pack_name.lower()
-    pack_key = pack_name_lower + "_UUIDs"
+    pack_name = pack.pack_name
+    pack_key = pack_name + "_UUIDs"
     target_pack_scan_UUID = pack_scan_UUIDs.get(pack_key)
 
     if target_pack_scan_UUID != None:
         target_pack_scan_UUID.append(website_ID)
-        create_pack_visitors(pack_name_lower)
+        create_pack_visitors(pack_name)
 
     else:
         pack_scan_UUIDs[pack_key] = [website_ID]
-        create_pack_visitors(pack_name_lower)
+        create_pack_visitors(pack_name)
 
 
-def create_card_visitors(card_name_lower: str):
+def create_card_visitors(card_name: str):
     """
     Creates an auxiliary dict entry to track who's viewed a card website
     """
+    card_name_lower = card_name.lower()
     i = 0
     while (card_scan_visitors.get(f"{card_name_lower+str(i)}_visitors") != None):
         i += 1
     card_scan_visitors[f"{card_name_lower+str(i)}_visitors"] = []
 
 
-def create_pack_visitors(pack_name_lower: str):
+def create_pack_visitors(pack_name: str):
     """
     Creates an auxiliary dict entry to track who's viewed a pack website\n
     This dictionary's value is another dict (UserID: timeEpoch)
     """
+    pack_name_lower = pack_name.lower()
     i = 0
     while (pack_scan_visitors.get(f"{pack_name_lower+str(i)}_visitors") != None):
         i += 1
     pack_scan_visitors[f"{pack_name_lower+str(i)}_visitors"] = dict()
 
 
-def get_card_from_ID(ID: str) -> Card:
+def get_card_from_ID(id) -> Card:
     """
     Returns Card if ID is in entry. Returns None if ID invalid.
     """
-    card_key = [key for key, val in card_scan_UUIDs.items() if ID in val]
-    if len(card_key) != 0:
-        card_name = card_key[:-6]
+    if type(id) != str:
+        id = str(id)
 
-        return Card.objects.get(card_name)
+
+    card_name = None
+    for key, val in card_scan_UUIDs.items():
+        if id in val:
+            card_name = key[:-6]
+
+    if card_name:
+        return Card.objects.get(card_name=card_name)
     else:
         return None
 
-def get_pack_from_ID(ID: str) -> Pack:
-    pass
+
+def get_pack_from_ID(id) -> Pack:
+    """
+    Returns Pack if ID is in entry. Returns None if ID invalid.
+    """
+    if type(id) != str:
+        id = str(id)
+    
+
+    pack_name = None
+    for key, val in pack_scan_UUIDs.items():
+        if id in val:
+            pack_name = key[:-6]
+            
+    if pack_name:
+        return Pack.objects.get(pack_name=pack_name)
+    else:
+        return None
+
 
 @require_http_methods(["GET"])
 @login_required
@@ -181,14 +206,14 @@ def card_scan(request, url_UUID):
         # return 404 invalid UUID was given
         render(ERROR_404_TEMPLATE_NAME)
     
+    card_name = card.card_name
     # Find prev_visitor_IDs list for this URL
-    card_name_lower = card.card_name.lower()
-    visitors_index = card_scan_UUIDs.get(f"{card_name_lower}_UUIDs").index(url_UUID)
-    prev_visitor_IDs = card_scan_visitors.get(f"{card_name_lower}{visitors_index}_visitors")
+    visitors_index = card_scan_UUIDs.get(f"{card_name}_UUIDs").index(url_UUID)
+    prev_visitor_IDs = card_scan_visitors.get(f"{card_name.lower()}{visitors_index}_visitors")
     
     cards_context = []
     cards_context.append({
-        "card_name": card.card_name,
+        "card_name": card_name,
         "card_desc": card.card_desc,
         "image_path": card.image,
     })
@@ -221,32 +246,31 @@ def pack_scan(request, url_UUID):
     It then adds those 5 cards to user's inventory
     """
     url_UUID = str(url_UUID)
+    base_pack = get_pack_instance() # Just to create initial pack
 
     current_user = request.user
     current_UD = UserData.objects.get(owner=current_user)
 
     # Initialise card values for given URL
-    if url_UUID in pack_scan_UUIDs.get("pack0_UUIDs"):
-        pack_cards_rar = get_pack_instance().get_all_cards_rar()
-        pack_cards = []
-        pack_rarity = []
-        for card_rar in pack_cards_rar:
-            pack_cards.append(card_rar[0])
-            pack_rarity.append(card_rar[1])
-        
-        # Randomly rolls for 5 cards. Every card in the pack has a chance to be chosen
-        selected_cards = rand.choices(pack_cards, weights=pack_rarity, k=5)
-
-        
-        # Find prev_visitor_IDs list for this URL
-
-        
-        visitors_index = pack_scan_UUIDs.get("pack0_UUIDs").index(url_UUID)
-        prev_visitor_IDs = pack_scan_visitors.get(f"pack{visitors_index}_visitor_IDs")
-
-    else:
-        # return 404 invalid UUID was given
+    pack = get_pack_from_ID(url_UUID)
+    if not pack:
         render(ERROR_404_TEMPLATE_NAME)
+        
+    pack_cards_rar = pack.get_all_cards_rar()
+    pack_cards = []
+    pack_rarity = []
+    for card_rar in pack_cards_rar:
+        pack_cards.append(card_rar[0])
+        pack_rarity.append(card_rar[1])
+        
+    # Randomly rolls for 5 cards. Every card in the pack has a chance to be chosen
+    selected_cards = rand.choices(pack_cards, weights=pack_rarity, k=5)
+
+    
+    pack_name = pack.pack_name
+    # Find prev_visitor_IDs list for this URL
+    visitors_index = pack_scan_UUIDs.get(f"{pack_name}_UUIDs").index(url_UUID)
+    prev_visitor_IDs = pack_scan_visitors.get(f"{pack_name.lower()}{visitors_index}_visitors")
 
     cards_context = []
     for card in selected_cards:
@@ -264,7 +288,7 @@ def pack_scan(request, url_UUID):
     # Epoch is used for claim cooldown
     # cooldown length can be set below (in seconds)
     # 86400 sec = 1 day
-    cooldown_period = 1
+    cooldown_period = 10
     cur_epoch = int(time.time())
     userID = current_user.id
 


### PR DESCRIPTION
**Rework card_scan backend**

Change card_scan endpoint in order to allow for addition of card_scan links.
Create functions to add new websites into the ID list and create a new list to track previous visitors of newly generated website.

**Features:**
- Functions to add a single-use QR code website ID’s to dictionary containing (Card: IDs) or (Pack: IDs)
- Functions to add a cooldown QR code website ID’s to dictionary containing (Card: IDs) or (Pack: IDs)